### PR TITLE
Kapiton feature/user/related products logo

### DIFF
--- a/resources/views/front/products/ajax_related_products_listings.blade.php
+++ b/resources/views/front/products/ajax_related_products_listings.blade.php
@@ -110,17 +110,18 @@
                         data-element_type="container"
                         data-settings="{&quot;content_width&quot;:&quot;full&quot;,&quot;container_type&quot;:&quot;flex&quot;}"
                     >
-                        @php
-                            $vendor_profile_image = null;
-                            if (isset($productDetails['vendor']['vendorbusinessdetails']['shop_logo']))
-                                $vendor_profile_image = $productDetails['vendor']['vendorbusinessdetails']['shop_logo'] != "" ? $productDetails['vendor']['vendorbusinessdetails']['shop_logo']:'2023-12-user.png';
+                    @php
+                        $vendor_profile_image = null;
+                        $vendorDetails = $product['vendor']['vendorbusinessdetails'] ?? null;
+                        $vendor_profile_image = !empty($vendorDetails['shop_logo'])
+                        ? $vendorDetails['shop_logo']
+                        : '2023-12-user.png';
                         @endphp
-                        <div
-                            class="elementor-element elementor-element-b1a54c1 elementor-widget elementor-widget-image"
+
+                        <div class="elementor-element elementor-element-b1a54c1 elementor-widget elementor-widget-image"
                             data-id="b1a54c1"
                             data-element_type="widget"
-                            data-widget_type="image.default"
-                        >
+                            data-widget_type="image.default">
                             <div class="elementor-widget-container">
                                 <img
                                     loading="lazy"
@@ -131,8 +132,7 @@
                                     class="attachment-large size-large wp-image-423"
                                     alt=""
                                     srcset="{{ $getImage('front/images/brand-logos/', $vendor_profile_image) }} 300w, {{ $getImage('front/images/brand-logos/', $vendor_profile_image) }} 150w"
-                                    sizes="(max-width: 300px) 100vw, 300px"
-                                >
+                                    sizes="(max-width: 300px) 100vw, 300px">
                             </div>
                         </div>
                         @if (!empty($product['vendor']['vendorbusinessdetails']))


### PR DESCRIPTION
Updated the logic for displaying the vendor's shop logo on product pages. The previous implementation showed the same logo for all related products. This fix tries to display each product with its associated shop logo correctly. A fallback logo is used if no logo is provided.
